### PR TITLE
go.mod: make car go-gettable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module car
+module github.com/teknoraver/car
 
 go 1.18
 


### PR DESCRIPTION
Use full github package name to make 'go install'
work.